### PR TITLE
Backwards compatibility with python2

### DIFF
--- a/python_githooks/helpers.py
+++ b/python_githooks/helpers.py
@@ -4,6 +4,10 @@ import stat
 from configparser import ConfigParser
 from .hook_template import hook_template
 
+try:
+    from shlex import quote as _quote
+except ImportError:
+    from pipes import quote as _quote
 
 def create_config_file(configfile_path):
     config = ConfigParser()
@@ -22,7 +26,7 @@ def create_git_hooks(configfile_path, githooks_dir):
                 command = hook['command']
                 githook_file = os.path.join(githooks_dir, section)
                 with open(githook_file, 'wb') as file:
-                    file.write(hook_template.format(section=section, command=command).encode())
+                    file.write(hook_template.format(section=section, command=repr(_quote(command))).encode())
                     st = os.stat(githook_file)
                     os.chmod(githook_file, st.st_mode | stat.S_IEXEC)
                 print('{} hook successfully created for running "{}"'.format(section, command))

--- a/python_githooks/hook_template.py
+++ b/python_githooks/hook_template.py
@@ -4,8 +4,7 @@ import os
 import sys
 
 def main():
-    print("python-githooks > {section}")
-    os.system("{command}")
+    os.system('sh -c ' + {command})
     sys.exit(0)
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,13 @@
 import os
 import sys
-import pathlib
 from setuptools import setup
 from setuptools.command.install import install
 
-HERE = pathlib.Path(__file__).parent
+HERE = os.path.dirname(__file__)
 
 VERSION = "1.0.5"
 
-README = (HERE / "README.md").read_text()
+README = open(os.path.join(HERE, "README.md")).read()
 
 
 class VerifyVersionCommand(install):


### PR DESCRIPTION
These simple commits from @ateijelo should make python-githooks compatible with python2